### PR TITLE
ImageCanvas and App now accept and draw any object conforming to the Drawable interface

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -6,7 +6,7 @@ import ImageObject, * as Loader from "./ImageObject";
 import ToolsPanel from "./ToolsPanel";
 import * as Exporter from "../lib/ImageExporter";
 import { saveAs } from "file-saver";
-import { EditorSettings } from "../lib/interfaces";
+import { Drawable, EditorSettings } from "../lib/interfaces";
 import "../styles/app.scss";
 import "../styles/toolbar.scss";
 
@@ -14,7 +14,7 @@ import "../styles/toolbar.scss";
 type ImageFile = File | null;
 
 function App(): JSX.Element {
-  const [image, setImage] = useState<ImageObject>(new ImageObject("img"));
+  const [image, setImage] = useState<Drawable>(new ImageObject("img"));
   const [editorSettings, setEditorSettings] = useState<EditorSettings>({
     grid: true,
     startingScale: 8
@@ -33,7 +33,7 @@ function App(): JSX.Element {
     if (!image) {
       alertMsg();
     } else {
-      let fileName = image.getFileName();
+      let fileName = image.fileName;
       let fileType = ".c";
       let fullFileName =
         fileName.slice(0, fileName.lastIndexOf(".")) + fileType;

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -1,14 +1,14 @@
 import React, { useReducer, useState, useRef, useEffect } from "react";
-import ImageObject from "./ImageObject";
 import {
   Color,
   ImageCoordinates,
   Dimensions,
+  Drawable,
   EditorSettings
 } from "../lib/interfaces";
 
 interface ImageCanvasProps {
-  imageObject: ImageObject;
+  imageObject: Drawable;
   settings: EditorSettings;
   onChangeScale: (newScale: number) => void;
 }
@@ -24,7 +24,7 @@ function ImageCanvas({
   settings,
   onChangeScale
 }: ImageCanvasProps): JSX.Element {
-  const [image, setImage] = useState<ImageObject>(imageObject);
+  const [image, setImage] = useState<Drawable>(imageObject);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [context, setContext] = useState<CanvasRenderingContext2D | null>(
     canvasRef ? getContext(canvasRef) : null
@@ -72,7 +72,7 @@ function ImageCanvas({
   useEffect(() => {
     const drawGrid = () => {
       if (!context) return;
-      const { width, height } = image.getDimensions();
+      const { width, height } = image.dimensions;
       context.strokeStyle = "gray";
       context.beginPath();
 
@@ -96,10 +96,10 @@ function ImageCanvas({
       context.fillRect(pos.x * scale, pos.y * scale, scale, scale);
     };
 
-    const drawImage = (image: ImageObject) => {
+    const drawImage = (image: Drawable) => {
       console.log("drawing the image...");
-      for (let x = 0; x < image.getDimensions().width; x++) {
-        for (let y = 0; y < image.getDimensions().height; y++) {
+      for (let x = 0; x < image.dimensions.width; x++) {
+        for (let y = 0; y < image.dimensions.height; y++) {
           drawPixel({ x, y }, image.getPixelColorAt({ x, y }));
         }
       }

--- a/src/components/ImageObject.tsx
+++ b/src/components/ImageObject.tsx
@@ -1,8 +1,13 @@
-import { Color, Dimensions, ImageCoordinates } from "../lib/interfaces";
+import {
+  Color,
+  Dimensions,
+  Drawable,
+  ImageCoordinates
+} from "../lib/interfaces";
 
-export default class ImageObject {
-  private fileName: string;
-  private dimensions: Dimensions = {
+export default class ImageObject implements Drawable {
+  public fileName: string;
+  public dimensions: Dimensions = {
     height: 32,
     width: 32
   };
@@ -34,6 +39,10 @@ export default class ImageObject {
     }
   }
 
+  public getImageData(): Uint8ClampedArray {
+    return this.imageData;
+  }
+
   public getPixelColorAt(pos: ImageCoordinates): Color {
     const context = this.hiddenCanvas.getContext("2d");
     if (context == null) {
@@ -51,18 +60,6 @@ export default class ImageObject {
         a: this.imageData[offset(pos, this.dimensions) + 3]
       };
     }
-  }
-
-  public getImageData(): Uint8ClampedArray {
-    return this.imageData;
-  }
-
-  public getFileName(): string {
-    return this.fileName;
-  }
-
-  public getDimensions(): Dimensions {
-    return this.dimensions;
   }
 }
 
@@ -105,9 +102,7 @@ export const loadImageDataFromCanvas = (
 };
 
 // is async necessary here???? I don't think it is
-export const loadHiddenImage = ( 
-  imagefile: File
-): Promise<HTMLImageElement> => {
+export const loadHiddenImage = (imagefile: File): Promise<HTMLImageElement> => {
   return new Promise((resolve, reject) => {
     let image = new Image();
     image.hidden = true;

--- a/src/components/ToolsPanel.tsx
+++ b/src/components/ToolsPanel.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from "react";
+import React from "react";
 import { EditorSettings } from "../lib/interfaces";
 import Toggle from "./buttons/Toggle";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";

--- a/src/components/buttons/Toggle.tsx
+++ b/src/components/buttons/Toggle.tsx
@@ -1,4 +1,4 @@
-import React, { useState, PropsWithChildren } from "react";
+import React, { PropsWithChildren } from "react";
 import "../../styles/buttons.scss";
 
 type ToggleProps = {

--- a/src/lib/ImageExporter.ts
+++ b/src/lib/ImageExporter.ts
@@ -1,13 +1,14 @@
 import ImageObject from "../components/ImageObject";
-import {image2hex} from "./converter";
+import { image2hex } from "./converter";
+import { Drawable } from "../lib/interfaces";
 
 export const ImageExporter = {
   getGBAImageString: (image: ImageObject) => getGBAImageString(image)
 };
 
-export function getGBAImageString(image: ImageObject): string {
+export function getGBAImageString(image: Drawable): string {
   let imageData = image.getImageData();
-  let imageName = image.getFileName();
+  let imageName = image.fileName;
   return image2hex(imageData, imageName);
 }
 

--- a/src/lib/interfaces.tsx
+++ b/src/lib/interfaces.tsx
@@ -1,3 +1,13 @@
+export interface Drawable {
+  dimensions: Dimensions;
+  fileName: string;
+  getPixelColorAt: (pos: ImageCoordinates) => Color;
+  // getImageData can be changed depending on how the Sprite object is
+  // implemented (if necessary) -- just make sure to also change ImageObject
+  // accordingly
+  getImageData: () => Uint8ClampedArray;
+}
+
 export interface MouseCoordinate {
   x: number;
   y: number;


### PR DESCRIPTION
ImageObject now properly implements the new Drawable interface as well - functionality is unchanged, but it's easier now to implement new types of Drawable things.