### PR TITLE
add new interface for images that can be modified

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { Drawable, EditorSettings } from "../lib/interfaces";
+import { ModifiableImage, EditorSettings } from "../lib/interfaces";
 import { getGBAImageString } from "../lib/exportUtils";
 import { saveAs } from "file-saver";
 import { Tools } from "../lib/consts";
@@ -15,7 +15,7 @@ import "../styles/toolbar.scss";
 type ImageFile = File | null;
 
 function App(): JSX.Element {
-  const [image, setImage] = useState<Drawable>(new ImageObject("img"));
+  const [image, setImage] = useState<ModifiableImage>(new ImageObject("img"));
   const [editorSettings, setEditorSettings] = useState<EditorSettings>({
     grid: true,
     startingScale: 8,

--- a/src/components/ImageCanvas.tsx
+++ b/src/components/ImageCanvas.tsx
@@ -2,13 +2,13 @@ import React, { useEffect, useReducer, useRef, useState } from "react";
 import {
   Color,
   Dimensions,
-  Drawable,
+  ModifiableImage,
   EditorSettings,
   ImageCoordinates
 } from "../lib/interfaces";
 
 interface ImageCanvasProps {
-  imageObject: Drawable;
+  imageObject: ModifiableImage;
   settings: EditorSettings;
   onChangeScale: (newScale: number) => void;
 }
@@ -24,7 +24,7 @@ function ImageCanvas({
   settings,
   onChangeScale
 }: ImageCanvasProps): JSX.Element {
-  const [image, setImage] = useState<Drawable>(imageObject);
+  const [image, setImage] = useState<ModifiableImage>(imageObject);
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const [context, setContext] = useState<CanvasRenderingContext2D | null>(
     canvasRef ? getContext(canvasRef) : null
@@ -96,7 +96,7 @@ function ImageCanvas({
       context.fillRect(pos.x * scale, pos.y * scale, scale, scale);
     };
 
-    const drawImage = (image: Drawable) => {
+    const drawImage = (image: ModifiableImage) => {
       console.log("drawing the image...");
       for (let x = 0; x < image.dimensions.width; x++) {
         for (let y = 0; y < image.dimensions.height; y++) {

--- a/src/components/ImageObject.tsx
+++ b/src/components/ImageObject.tsx
@@ -1,11 +1,11 @@
 import {
   Color,
   Dimensions,
-  Drawable,
+  ModifiableImage,
   ImageCoordinates
 } from "../lib/interfaces";
 
-export default class ImageObject implements Drawable {
+export default class ImageObject implements ModifiableImage {
   public fileName: string;
   public dimensions: Dimensions = {
     height: 32,
@@ -60,6 +60,12 @@ export default class ImageObject implements Drawable {
         a: this.imageData[offset(pos, this.dimensions) + 3]
       };
     }
+  }
+
+  public setPixelColor(pos: ImageCoordinates, paletteIndex: number) {
+    console.warn("Method setPixelColor in ImageObject not implemented yet. "
+      + "Returning the current image.");
+    return this;
   }
 }
 

--- a/src/lib/interfaces.ts
+++ b/src/lib/interfaces.ts
@@ -22,6 +22,13 @@ export interface Drawable {
   getImageData: () => Uint8ClampedArray;
 }
 
+export interface ModifiableImage extends Drawable {
+  setPixelColor: (
+    pos: ImageCoordinates,
+    paletteIndex: number
+  ) => ModifiableImage;
+}
+
 export interface EditorSettings {
   grid: boolean;
   startingScale: number;


### PR DESCRIPTION
`App`, `ImageCanvas`, and `ImageObject` have all been changed to accept this new interface as well. Functionality should be unchanged.