### PR TITLE
Re-implement mode 3 image export

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -32,9 +32,9 @@ function App(): JSX.Element {
     if (imageFile) {
       console.log("Loading image...");
       let image = await loadNewImage(imageFile);
-      let { palette, sprite } = quantize(image, 16);
-      setImage(sprite);
-      setPalette(palette);
+      // let { palette, sprite } = quantize(image, 16);
+      setImage(image);
+      // setPalette(palette);
     }
   };
 

--- a/src/components/objects/ImageObject.tsx
+++ b/src/components/objects/ImageObject.tsx
@@ -4,7 +4,10 @@ import {
   ImageInterface,
   ImageCoordinates
 } from "../../lib/interfaces";
-import { generateHeaderString } from "../../lib/exportUtils";
+import {
+  generateHeaderString,
+  generateCSourceFileString
+} from "../../lib/exportUtils";
 import * as Loader from "../../lib/imageLoadUtils";
 
 export default class ImageObject implements ImageInterface {
@@ -49,7 +52,7 @@ export default class ImageObject implements ImageInterface {
   }
 
   public getCSourceData(): string {
-    return "";
+    return generateCSourceFileString(this, 3);
   }
 
   public getImageData(): Uint8ClampedArray {

--- a/src/lib/exportUtils.ts
+++ b/src/lib/exportUtils.ts
@@ -39,7 +39,7 @@ function generateMode3CSourceFileString(image: ImageInterface): string {
     let hexcode = pixelToHex(bgr);
     imageDataHexString += hexcode + ",";
     pixelCount++;
-    if (pixelCount % 8 === 0 && pixelCount < 256) {
+    if (pixelCount % 8 === 0) {
       imageDataHexString += "\n";
       if (pixelCount % 64 === 0) {
         imageDataHexString += "\n\t";


### PR DESCRIPTION
If someone could check that it's still approximately identical to Usenti's output, that would be great. It works for at least the Pow block image, that's what I tested it with.